### PR TITLE
Keep docstrings intact in decorators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 New:
 
+- Keep docstrings intact in decorators.
+  [pgrunewald]
+
 - *add item here*
 
 Fixes:

--- a/plone/memoize/instance.py
+++ b/plone/memoize/instance.py
@@ -5,6 +5,7 @@ Stores values in an attribute on the instance. See instance.rst.
 
 This package current subsumes memojito.
 """
+from functools import wraps
 
 _marker = object()
 
@@ -35,6 +36,7 @@ class Memojito(object):
 
     def memoize(self, func):
 
+        @wraps(func)
         def memogetter(*args, **kwargs):
             inst = args[0]
             cache = getattr(inst, self.propname, _marker)

--- a/plone/memoize/request.py
+++ b/plone/memoize/request.py
@@ -3,7 +3,7 @@
 
 Stores values in an annotation of the request.
 """
-
+from functools import wraps
 from plone.memoize import volatile
 from zope.annotation.interfaces import IAnnotations
 import inspect
@@ -20,6 +20,7 @@ class RequestMemo(object):
 
     def __call__(self, func):
 
+        @wraps(func)
         def memogetter(*args, **kwargs):
             request = None
             if isinstance(self.arg, int):

--- a/plone/memoize/view.py
+++ b/plone/memoize/view.py
@@ -3,7 +3,7 @@
 
 Stores values in an annotation of the request. See view.rst.
 """
-
+from functools import wraps
 from zope.annotation.interfaces import IAnnotations
 
 _marker = object()
@@ -15,6 +15,7 @@ class ViewMemo(object):
 
     def memoize(self, func):
 
+        @wraps(func)
         def memogetter(*args, **kwargs):
             instance = args[0]
 

--- a/plone/memoize/volatile.py
+++ b/plone/memoize/volatile.py
@@ -5,6 +5,7 @@ This module provides a cache decorator `cache` that you can use to
 cache results of your functions or methods.
 """
 
+from functools import wraps
 import time
 
 
@@ -59,6 +60,7 @@ def cache(get_key, get_cache=store_on_self):
 
     def decorator(fun):
 
+        @wraps(fun)
         def replacement(*args, **kwargs):
             try:
                 key = get_key(fun, *args, **kwargs)

--- a/plone/memoize/volatile.rst
+++ b/plone/memoize/volatile.rst
@@ -15,6 +15,7 @@ Let's say we have a class with an expensive method `pow` that we want to cache::
 
     >>> class MyClass:
     ...     def pow(self, first, second):
+    ...         """Returns the number 'first' to the power of 'second'."""
     ...         print('Someone or something called me')
     ...         return first ** second
 
@@ -35,6 +36,7 @@ Let's define our first class again, this time with a cached `pow` method::
     >>> class MyClass:
     ...     @cache(cache_key)
     ...     def pow(self, first, second):
+    ...         """Returns the number 'first' to the power of 'second'."""
     ...         print('Someone or something called me')
     ...         return first ** second
 
@@ -48,6 +50,11 @@ The results::
     9
 
 Did you see that?  The method was called only once.
+
+You can also see, that the method's docstring is still intact::
+
+    >>> obj.pow.__doc__
+    "Returns the number 'first' to the power of 'second'."
 
 Now to where this cache is stored: That's actually variable.
 The cache decorator takes an optional second argument with which you can define the where the cache is stored to.


### PR DESCRIPTION
I happened to notice, that using the decorators in plone.memoize strips all the docstrings. This is counter-productive, when trying to document your source code with tools like Sphinx. This PR tries to solve this by using [functools.wraps](https://docs.python.org/2/library/functools.html#functools.wraps). A test has been added as well.