### PR TITLE
Remove zope.testrunner as a test dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ Bug fixes:
   plone.memoize is being tested on jenkins.plone.org.
   [gforcada]
 
+- Clean up dependencies.
+  [gforcada]
+
+
 1.2.1 (2017-07-03)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         test=[
             'zope.configuration',
             'zope.publisher',
-            'zope.testrunner',
         ]
     ),
     install_requires=[


### PR DESCRIPTION
One could run the tests with something else and there is nothing specific about zope.testrunner used either.