### PR TITLE
Re-enable Travis-CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+branch = True
+source = plone
+
+[report]
+precision = 2

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ __pycache__
 .tox
 .eggs
 .coverage
+coverage.xml
 /htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+sudo: false
+python:
+    - 2.7
+    - 3.5
+    - 3.6
+install:
+    - pip install zc.buildout
+    - pip install coveralls coverage
+    - buildout bootstrap
+    - buildout install test
+script:
+    - coverage run bin/tests -v
+after_success:
+    - coveralls
+notifications:
+    email: false
+cache:
+  pip: true
+  directories:
+    - eggs/

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,15 +1,34 @@
 [buildout]
+extends = http://dist.plone.org/release/5-latest/versions.cfg
 develop = .
-parts = test createcoverage
+parts = test
+
+[versions]
+persistent = >= 4
+python-gettext = >= 3
+zc.recipe.testrunner = >= 2
+zope.annotation = >= 4
+zope.browser = >= 2
+zope.component = >= 4
+zope.configuration = >= 4
+zope.contenttype = >= 4
+zope.deprecation = >= 4
+zope.event = >= 4
+zope.exceptions = >= 4
+zope.i18n = >= 4
+zope.i18nmessageid = >= 4
+zope.interface = >= 4
+zope.location = >= 4
+zope.proxy = >= 4
+zope.publisher = >= 4
+zope.ramcache = >= 2
+zope.schema = >= 4
+zope.security = >= 4
+zope.testing = >= 4
+zope.testrunner = >= 4
+plone.memoize =
 
 [test]
 recipe = zc.recipe.testrunner
 eggs =
    plone.memoize [test]
-
-[createcoverage]
-recipe = zc.recipe.egg
-dependent-scripts = true
-eggs =
-   createcoverage
-   ${test:eggs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,30 @@
+[tox]
+envlist = py27,
+          py35,
+          py36,
+          coverage-report,
+
+[testenv]
+commands =
+    {envbindir}/buildout -c {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} bootstrap
+    {envbindir}/buildout -c {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    coverage run {envbindir}/test {posargs:-vc}
+skip_install = true
+deps =
+    coverage
+    zc.buildout
+setenv =
+    COVERAGE_FILE=.coverage.{envname}
+
+[testenv:coverage-report]
+basepython = python3.6
+deps = coverage
+setenv =
+    COVERAGE_FILE=.coverage
+skip_install = true
+commands =
+    coverage erase
+    coverage combine
+    coverage html -i
+    coverage xml -i
+    coverage report -i --fail-under=79


### PR DESCRIPTION
This package can be used outside Plone so it should be tested outside, too. This reverts #8 and adds a bit of infrastructure to get more reliable builds for testing.

Currently the tests fail because it is not compatible with current versions of the packages it depends on.
(I am planning to work on the tests failures later on.)