### PR TITLE
Drop 3.4 support, add 3.7, 3.8, PyPy, PyPy3 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
-sudo: false
 python:
     - 2.7
     - 3.5
     - 3.6
+    - 3.7
+    - 3.8
+    - pypy
+    - pypy3
 install:
     - pip install zc.buildout
     - pip install coveralls coverage

--- a/news/16.feature
+++ b/news/16.feature
@@ -1,0 +1,2 @@
+Drop 3.4 support, add 3.7, 3.8, PyPy, PyPy3 support.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,11 @@
 envlist = py27,
           py35,
           py36,
-          coverage-report,
+          py37,
+          py38,
+          pypy,
+          pypy3,
+          coverage-report
 
 [testenv]
 commands =


### PR DESCRIPTION
3.4 was not tested for a long time.
3.7, 3.8 and PyPy were claimed, but not tested.

Note: no code change, so no Jenkins jobs needed.

Status after this:

```
$ check-python-versions
setup.py says:              2.7, 3.5, 3.6, 3.7, 3.8, PyPy
tox.ini says:               2.7, 3.5, 3.6, 3.7, 3.8, PyPy, PyPy3
.travis.yml says:           2.7, 3.5, 3.6, 3.7, 3.8, PyPy, PyPy3
```

Note that you cannot specify PyPy3 in `setup.py`, there is no such classifier.