### PR TITLE
Removed more Python 2 compatibility code, pointed to by coverage

### DIFF
--- a/news/55.internal
+++ b/news/55.internal
@@ -1,0 +1,2 @@
+Removed more Python 2 compatibility code.
+[maurits]

--- a/plone/memoize/request.py
+++ b/plone/memoize/request.py
@@ -3,17 +3,9 @@
 Stores values in an annotation of the request.
 """
 from functools import wraps
+from inspect import getfullargspec
 from plone.memoize import volatile
 from zope.annotation.interfaces import IAnnotations
-
-import inspect
-
-
-try:
-    getargspec = inspect.getfullargspec
-except AttributeError:
-    # for Python 2
-    getargspec = inspect.getargspec
 
 
 _marker = object()
@@ -58,7 +50,7 @@ def store_in_annotation_of(expr):
     def _store_in_annotation(fun, *args, **kwargs):
         # Use expr to find out the name of the request variable
         vars = {}
-        spec = getargspec(fun)
+        spec = getfullargspec(fun)
         num_args = len(args)
         expected_num_args = num_args
 

--- a/tox.ini
+++ b/tox.ini
@@ -68,3 +68,17 @@ commands =
     zope-testrunner --all --test-path={toxinidir} -s plone.memoize {posargs}
 extras =
     test
+
+[testenv:coverage]
+usedevelop = true
+constrain_package_deps = true
+set_env = ROBOT_BROWSER=headlesschrome
+deps =
+    coverage
+    zope.testrunner
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+commands =
+    coverage run {envbindir}/zope-testrunner --all --test-path={toxinidir} -s plone.memoize {posargs}
+    coverage report -m --format markdown
+extras =
+    test


### PR DESCRIPTION
This increases the coverage from 89 to... 89 percent.  So not much. ;-)  This was easy, the rest is more tricky.

```
coverage: commands[1]> coverage report -m --format markdown
| Name                          |    Stmts |     Miss |   Cover |   Missing |
|------------------------------ | -------: | -------: | ------: | --------: |
| plone/memoize/\_\_init\_\_.py |        0 |        0 |    100% |           |
| plone/memoize/compress.py     |        7 |        0 |    100% |           |
| plone/memoize/forever.py      |        9 |        0 |    100% |           |
| plone/memoize/instance.py     |       43 |        0 |    100% |           |
| plone/memoize/interfaces.py   |        5 |        0 |    100% |           |
| plone/memoize/ram.py          |       60 |       12 |     80% |32-33, 36-38, 41-45, 48-49, 88 |
| plone/memoize/request.py      |       47 |       18 |     62% |18, 21-46, 64 |
| plone/memoize/tests.py        |       15 |        0 |    100% |           |
| plone/memoize/view.py         |       49 |        0 |    100% |           |
| plone/memoize/volatile.py     |       49 |        1 |     98% |        58 |
|                     **TOTAL** |  **284** |   **31** | **89%** |
```